### PR TITLE
Fix for 'file could not be saved' when file is already saved

### DIFF
--- a/src/VSCodeAdapter.ts
+++ b/src/VSCodeAdapter.ts
@@ -73,12 +73,14 @@ export default class VSCodeAdapter {
     }
 
     private saveFile(callback) {
-        setTimeout(() => {
+        if (this.doc.isDirty) {
             this.doc.save().then(
                 (wasSaved) => {
                     callback(wasSaved);
                 });
-        }, 100);
+        } else {
+            callback(true);
+        }
     }
 
     private lastTextLine(): string {


### PR DESCRIPTION
Hi, thanks for very useful extension!

But it has very annoying behaviour, look at this gif please:

![blank-line-before](https://cloud.githubusercontent.com/assets/200119/15450719/1f0a8868-1fac-11e6-8dd4-fe5d350f9fdf.gif)

As you can see here, file was saved but error popup showed up. It happens because document is already saved when `saveFile` method is called. And vscode obviously can't save file again and that's why `false` is passed to callback.

The solution I came up with is to check whether document is dirty and only then call save.

Gif after changes from this PR:

![blank-line-after](https://cloud.githubusercontent.com/assets/200119/15450734/a87cd3f8-1fac-11e6-8178-d45c8d1b38a2.gif)
